### PR TITLE
Add fs prefix (directory)

### DIFF
--- a/pkg/s3/mounter_goofys.go
+++ b/pkg/s3/mounter_goofys.go
@@ -60,8 +60,9 @@ func (goofys *goofysMounter) Mount(source string, target string) error {
 
 	os.Setenv("AWS_ACCESS_KEY_ID", goofys.accessKeyID)
 	os.Setenv("AWS_SECRET_ACCESS_KEY", goofys.secretAccessKey)
+	fullPath := fmt.Sprintf("%s:%s", goofys.bucket.Name, goofys.bucket.FSPath)
 
-	_, _, err := goofysApi.Mount(context.Background(), goofys.bucket.Name, goofysCfg)
+	_, _, err := goofysApi.Mount(context.Background(), fullPath, goofysCfg)
 
 	if err != nil {
 		return fmt.Errorf("Error mounting via goofys: %s", err)

--- a/pkg/s3/mounter_s3fs.go
+++ b/pkg/s3/mounter_s3fs.go
@@ -39,7 +39,7 @@ func (s3fs *s3fsMounter) Mount(source string, target string) error {
 		return err
 	}
 	args := []string{
-		fmt.Sprintf("%s", s3fs.bucket.Name),
+		fmt.Sprintf("%s:/%s", s3fs.bucket.Name, s3fs.bucket.FSPath),
 		fmt.Sprintf("%s", target),
 		"-o", "sigv2",
 		"-o", "use_path_request_style",

--- a/pkg/s3/mounter_s3ql.go
+++ b/pkg/s3/mounter_s3ql.go
@@ -49,7 +49,9 @@ func newS3qlMounter(b *bucket, cfg *Config) (Mounter, error) {
 		ssl:        ssl,
 	}
 
-	url.Path = path.Join(url.Path, b.Name)
+	// s3ql requires a trailing slash or it will just
+	// prepend the fspath to the s3ql files
+	url.Path = path.Join(url.Path, b.Name, b.FSPath) + "/"
 	s3ql.bucketURL = url.String()
 
 	if !ssl {

--- a/pkg/s3/s3-client.go
+++ b/pkg/s3/s3-client.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	metadataName = ".metadata.json"
+	fsPrefix     = "csi-fs"
 )
 
 type s3Client struct {
@@ -22,6 +23,7 @@ type s3Client struct {
 
 type bucket struct {
 	Name          string
+	FSPath        string
 	CapacityBytes int64
 }
 
@@ -52,6 +54,14 @@ func (client *s3Client) bucketExists(bucketName string) (bool, error) {
 
 func (client *s3Client) createBucket(bucketName string) error {
 	return client.minio.MakeBucket(bucketName, client.cfg.Region)
+}
+
+func (client *s3Client) createPrefix(bucketName string, prefix string) error {
+	_, err := client.minio.PutObject(bucketName, prefix+"/", bytes.NewReader([]byte("")), 0, minio.PutObjectOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (client *s3Client) removeBucket(bucketName string) error {


### PR DESCRIPTION
This ensures the fs root is clean and does not mess with the metadata. Also in the future this will allow for multiple filesystems to be created in one bucket.