### PR TITLE
Optimize the code framework

### DIFF
--- a/deploy/kubernetes/csi-s3.yaml
+++ b/deploy/kubernetes/csi-s3.yaml
@@ -95,6 +95,9 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
+            - name: plugins-dir
+              mountPath: /var/lib/kubelet/plugins
+              mountPropagation: "Bidirectional"
             - name: plugin-dir
               mountPath: /csi
             - name: pods-mount-dir
@@ -103,6 +106,10 @@ spec:
             - name: fuse-device
               mountPath: /dev/fuse
       volumes:
+        - name: plugins-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins
+            type: Directory
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry/

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -1,0 +1,45 @@
+package common
+
+import (
+	"hash/fnv"
+	"sync"
+
+	"k8s.io/utils/mount"
+)
+
+type KeyMutex struct {
+	mutexes []sync.RWMutex
+	size    int32
+}
+
+func HashToUint32(data []byte) uint32 {
+	h := fnv.New32a()
+	h.Write(data)
+
+	return h.Sum32()
+}
+
+func NewKeyMutex(size int32) *KeyMutex {
+	return &KeyMutex{
+		mutexes: make([]sync.RWMutex, size),
+		size:    size,
+	}
+}
+
+func (km *KeyMutex) GetMutex(key string) *sync.RWMutex {
+	hashed := HashToUint32([]byte(key))
+	index := hashed % uint32(km.size)
+
+	return &km.mutexes[index]
+}
+
+// CleanupMountPoint unmounts the given path and deletes the remaining directory
+func CleanupMountPoint(mountPath string) error {
+	mounter := mount.New("")
+
+	if err := mount.CleanupMountPoint(mountPath, mounter, true); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -21,6 +21,8 @@ import (
 	"github.com/golang/glog"
 
 	csicommon "github.com/kubernetes-csi/drivers/pkg/csi-common"
+
+	"github.com/ctrox/csi-s3/pkg/common"
 )
 
 type driver struct {
@@ -66,6 +68,7 @@ func (s3 *driver) newControllerServer(d *csicommon.CSIDriver) *controllerServer 
 func (s3 *driver) newNodeServer(d *csicommon.CSIDriver) *nodeServer {
 	return &nodeServer{
 		DefaultNodeServer: csicommon.NewDefaultNodeServer(d),
+		volumeMutexes:     common.NewKeyMutex(32),
 	}
 }
 

--- a/pkg/driver/volume.go
+++ b/pkg/driver/volume.go
@@ -1,0 +1,81 @@
+package driver
+
+import (
+	"github.com/ctrox/csi-s3/pkg/mounter"
+	"github.com/golang/glog"
+)
+
+type Volume struct {
+	VolumeId string
+
+	// volume's real mount point
+	stagingTargetPath string
+
+	// Target paths to which the volume has been published.
+	// These paths are symbolic links to the real mount point.
+	// So multiple pods using the same volume can share a mount.
+	targetPaths map[string]bool
+
+	mounter mounter.Mounter
+}
+
+func NewVolume(volumeID string, mounter mounter.Mounter) *Volume {
+	return &Volume{
+		VolumeId:    volumeID,
+		mounter:     mounter,
+		targetPaths: make(map[string]bool),
+	}
+}
+
+func (vol *Volume) Stage(stagingTargetPath string) error {
+	if vol.isStaged() {
+		return nil
+	}
+
+	if err := vol.mounter.Stage(stagingTargetPath); err != nil {
+		return err
+	}
+
+	vol.stagingTargetPath = stagingTargetPath
+	return nil
+}
+
+func (vol *Volume) Publish(targetPath string) error {
+	if err := vol.mounter.Mount(vol.stagingTargetPath, targetPath); err != nil {
+		return err
+	}
+
+	vol.targetPaths[targetPath] = true
+	return nil
+}
+
+func (vol *Volume) Unpublish(targetPath string) error {
+	// Check whether the volume is published to the target path.
+	if _, ok := vol.targetPaths[targetPath]; !ok {
+		glog.Warningf("volume %s hasn't been published to %s", vol.VolumeId, targetPath)
+		return nil
+	}
+
+	if err := vol.mounter.Unmount(targetPath); err != nil {
+		return err
+	}
+
+	delete(vol.targetPaths, targetPath)
+	return nil
+}
+
+func (vol *Volume) Unstage(_ string) error {
+	if !vol.isStaged() {
+		return nil
+	}
+
+	if err := vol.mounter.Unstage(vol.stagingTargetPath); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (vol *Volume) isStaged() bool {
+	return vol.stagingTargetPath != ""
+}

--- a/pkg/mounter/goofys.go
+++ b/pkg/mounter/goofys.go
@@ -74,3 +74,7 @@ func (goofys *goofysMounter) Mount(source string, target string) error {
 	}
 	return nil
 }
+
+func (goofys *goofysMounter) Unmount(target string) error {
+	return FuseUnmount(target)
+}

--- a/pkg/mounter/mounter.go
+++ b/pkg/mounter/mounter.go
@@ -22,6 +22,7 @@ type Mounter interface {
 	Stage(stagePath string) error
 	Unstage(stagePath string) error
 	Mount(source string, target string) error
+	Unmount(target string) error
 }
 
 const (

--- a/pkg/mounter/rclone.go
+++ b/pkg/mounter/rclone.go
@@ -57,3 +57,7 @@ func (rclone *rcloneMounter) Mount(source string, target string) error {
 	os.Setenv("AWS_SECRET_ACCESS_KEY", rclone.secretAccessKey)
 	return fuseMount(target, rcloneCmd, args)
 }
+
+func (rclone *rcloneMounter) Unmount(target string) error {
+	return FuseUnmount(target)
+}

--- a/pkg/mounter/s3backer.go
+++ b/pkg/mounter/s3backer.go
@@ -8,6 +8,7 @@ import (
 
 	osexec "os/exec"
 
+	"github.com/ctrox/csi-s3/pkg/common"
 	"github.com/ctrox/csi-s3/pkg/s3"
 	"github.com/golang/glog"
 	"k8s.io/mount-utils"
@@ -94,6 +95,10 @@ func (s3backer *s3backerMounter) Mount(source string, target string) error {
 		return err
 	}
 	return nil
+}
+
+func (s3backer *s3backerMounter) Unmount(target string) error {
+	return common.CleanupMountPoint(target)
 }
 
 func (s3backer *s3backerMounter) mountInit(p string) error {

--- a/pkg/mounter/s3fs.go
+++ b/pkg/mounter/s3fs.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"path"
 
+	"k8s.io/utils/mount"
+
+	"github.com/ctrox/csi-s3/pkg/common"
 	"github.com/ctrox/csi-s3/pkg/s3"
 )
 
@@ -30,27 +33,47 @@ func newS3fsMounter(meta *s3.FSMeta, cfg *s3.Config) (Mounter, error) {
 }
 
 func (s3fs *s3fsMounter) Stage(stageTarget string) error {
-	return nil
-}
-
-func (s3fs *s3fsMounter) Unstage(stageTarget string) error {
-	return nil
-}
-
-func (s3fs *s3fsMounter) Mount(source string, target string) error {
 	if err := writes3fsPass(s3fs.pwFileContent); err != nil {
 		return err
 	}
 	args := []string{
 		fmt.Sprintf("%s:/%s", s3fs.meta.BucketName, path.Join(s3fs.meta.Prefix, s3fs.meta.FSPath)),
-		target,
+		stageTarget,
 		"-o", "use_path_request_style",
 		"-o", fmt.Sprintf("url=%s", s3fs.url),
 		"-o", fmt.Sprintf("endpoint=%s", s3fs.region),
 		"-o", "allow_other",
 		"-o", "mp_umask=000",
 	}
-	return fuseMount(target, s3fsCmd, args)
+	return fuseMount(stageTarget, s3fsCmd, args)
+}
+
+func (s3fs *s3fsMounter) Unstage(stageTarget string) error {
+	if err := FuseUnmount(stageTarget); err != nil {
+		return err
+	}
+
+	if err := os.Remove(stageTarget); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	return nil
+}
+
+func (s3fs *s3fsMounter) Mount(source string, target string) error {
+	mounter := mount.New("")
+	// Use bind mount to create an alias of the real mount point.
+	mountOptions := []string{"bind"}
+
+	if err := mounter.Mount(source, target, "", mountOptions); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s3fs *s3fsMounter) Unmount(target string) error {
+	return common.CleanupMountPoint(target)
 }
 
 func writes3fsPass(pwFileContent string) error {


### PR DESCRIPTION
# What problem are we solving?
When we use the `s3fs` mounter, even if multiple pods use the same volume, the driver will start a process for each of them to mount the volume. This is wasteful of resources and bad for management.

```
o ps -ef | grep s3fs | grep pod
root     26654  3594  0 15:47 ?        00:00:00 s3fs custom / /var/lib/kubelet/pods/7e72ff6c-8096-4de3-973f-9d1a97fc3a89/volumes/kubernetes.io~csi/pvc-1a2313d1-ae74-45ee-bfa4-63106d7084ec/mount -o use_path_request_style -o url=http://10.134.80.223:9000 -o endpoint= -o allow_other -o mp_umask=000
root     34834  3594  0 19:32 ?        00:00:00 s3fs custom / /var/lib/kubelet/pods/5b8a4cb7-3897-42eb-94cf-049d0485a11b/volumes/kubernetes.io~csi/pvc-1a2313d1-ae74-45ee-bfa4-63106d7084ec/mount -o use_path_request_style -o url=http://10.134.80.223:9000 -o endpoint= -o allow_other -o mp_umask=000
```

# How are we solving the problem?
The idea is that pods using the same volume need to share a mount process.
We currently solve this problem based on the [CSI specification](https://github.com/container-storage-interface/spec/blob/master/spec.md). 

1. When a volume is first used on a node, `NodeStageVolume` will start a process to mount it to host's `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/<pvc>/globalmount` directory.
2.  Later when other pod uses the volume, `NodePublishVolume` just needs to bind mount `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/<pvc>/globalmount` to `/var/lib/kubelet/pods/<pod>/volumes/kubernetes.io~csi/<pvc>/mount` directory.
3. If the pod using the volume on the node is deleted, then `NodeUnpublishVolume` only needs to unmount  `/var/lib/kubelet/pods/<pod>/volumes/kubernetes.io~csi/<pvc>/mount`.
4. Finally, when the volume is not used by any pods on the node, `NodeUnstageVolume` will unmount the volume from `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/<pvc>/globalmount` directory.

We made a significant change to the code to make it easier to perform similar optimizations for other mounters.

Additionally, according to the specification, we also consider scenarios for handling concurrent calls.
https://github.com/container-storage-interface/spec/blob/master/spec.md#concurrency


