### PR TITLE
Added ability to specify gid and uid

### DIFF
--- a/deploy/kubernetes/csi-s3.yaml
+++ b/deploy/kubernetes/csi-s3.yaml
@@ -81,7 +81,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: ctrox/csi-s3:v1.2.0-rc.2
+          image: ctrox/csi-s3:v1.3.0
           imagePullPolicy: "Always"
           args:
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/kubernetes/examples/storageclass.yaml
+++ b/deploy/kubernetes/examples/storageclass.yaml
@@ -8,8 +8,14 @@ parameters:
   # specify which mounter to use
   # can be set to rclone, s3fs, goofys or s3backer
   mounter: rclone
+
   # to use an existing bucket, specify it here:
   # bucket: some-existing-bucket
+
+  # to use a non-root uid and gid, specify them here:
+  # uid: "33"
+  # gid: "33"
+
   csi.storage.k8s.io/provisioner-secret-name: csi-s3-secret
   csi.storage.k8s.io/provisioner-secret-namespace: kube-system
   csi.storage.k8s.io/controller-publish-secret-name: csi-s3-secret

--- a/deploy/kubernetes/provisioner.yaml
+++ b/deploy/kubernetes/provisioner.yaml
@@ -86,7 +86,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/kubelet/plugins/ch.ctrox.csi.s3-driver
         - name: csi-s3
-          image: ctrox/csi-s3:v1.2.0-rc.2
+          image: ctrox/csi-s3:v1.3.0
           args:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(NODE_ID)"

--- a/pkg/driver/controllerserver.go
+++ b/pkg/driver/controllerserver.go
@@ -53,6 +53,16 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	prefix := ""
 	usePrefix, usePrefixError := strconv.ParseBool(params[mounter.UsePrefix])
 	defaultFsPath := defaultFsPath
+	gid := uint32(0)
+	uid := uint32(0)
+	if params[mounter.Gid] != "" {
+		parsed, _ := strconv.ParseInt(params[mounter.Gid], 10, 32)
+		gid = uint32(parsed)
+	}
+	if params[mounter.Uid] != "" {
+		parsed, _ := strconv.ParseInt(params[mounter.Uid], 10, 32)
+		uid = uint32(parsed)
+	}
 
 	// check if bucket name is overridden
 	if nameOverride, ok := params[mounter.BucketKey]; ok {
@@ -93,6 +103,8 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		Mounter:       mounterType,
 		CapacityBytes: capacityBytes,
 		FSPath:        defaultFsPath,
+		Uid:           uid,
+		Gid:           gid,
 	}
 
 	client, err := s3.NewClientFromSecret(req.GetSecrets())

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -33,7 +33,7 @@ type driver struct {
 }
 
 var (
-	vendorVersion = "v1.2.0-rc.2"
+	vendorVersion = "v1.3.0"
 	driverName    = "ch.ctrox.csi.s3-driver"
 )
 

--- a/pkg/mounter/goofys.go
+++ b/pkg/mounter/goofys.go
@@ -61,6 +61,8 @@ func (goofys *goofysMounter) Mount(source string, target string) error {
 		Backend: &common.S3Config{
 			Region: goofys.region,
 		},
+		Gid: goofys.meta.Gid,
+		Uid: goofys.meta.Uid,
 	}
 
 	os.Setenv("AWS_ACCESS_KEY_ID", goofys.accessKeyID)

--- a/pkg/mounter/mounter.go
+++ b/pkg/mounter/mounter.go
@@ -33,6 +33,8 @@ const (
 	BucketKey           = "bucket"
 	VolumePrefix        = "prefix"
 	UsePrefix           = "usePrefix"
+	Gid                 = "gid"
+	Uid                 = "uid"
 )
 
 // New returns a new mounter depending on the mounterType parameter

--- a/pkg/mounter/rclone.go
+++ b/pkg/mounter/rclone.go
@@ -53,6 +53,14 @@ func (rclone *rcloneMounter) Mount(source string, target string) error {
 		// TODO: make this configurable
 		"--vfs-cache-mode=writes",
 	}
+
+	if rclone.meta.Gid != 0 {
+		args = append(args, fmt.Sprintf("--gid=%d", rclone.meta.Gid))
+	}
+	if rclone.meta.Uid != 0 {
+		args = append(args, fmt.Sprintf("--uid=%d", rclone.meta.Uid))
+	}
+
 	os.Setenv("AWS_ACCESS_KEY_ID", rclone.accessKeyID)
 	os.Setenv("AWS_SECRET_ACCESS_KEY", rclone.secretAccessKey)
 	return fuseMount(target, rcloneCmd, args)

--- a/pkg/mounter/s3backer.go
+++ b/pkg/mounter/s3backer.go
@@ -116,6 +116,13 @@ func (s3backer *s3backerMounter) mountInit(p string) error {
 		args = append(args, "--ssl")
 	}
 
+	if s3backer.meta.Gid != 0 {
+		args = append(args, fmt.Sprintf("--gid=%d", s3backer.meta.Gid))
+	}
+	if s3backer.meta.Uid != 0 {
+		args = append(args, fmt.Sprintf("--uid=%d", s3backer.meta.Uid))
+	}
+
 	return fuseMount(p, s3backerCmd, args)
 }
 

--- a/pkg/mounter/s3fs.go
+++ b/pkg/mounter/s3fs.go
@@ -52,10 +52,12 @@ func (s3fs *s3fsMounter) Mount(source string, target string) error {
 	}
 
 	if s3fs.meta.Gid != 0 {
-		args = append(args, fmt.Sprintf("-o", fmt.Sprintf("gid=%d", s3fs.meta.Gid)))
+		args = append(args, "-o")
+		args = append(args, fmt.Sprintf("gid=%d", s3fs.meta.Gid))
 	}
 	if s3fs.meta.Uid != 0 {
-		args = append(args, fmt.Sprintf("-o", fmt.Sprintf("uid=%d", s3fs.meta.Uid)))
+		args = append(args, "-o")
+		args = append(args, fmt.Sprintf("uid=%d", s3fs.meta.Uid))
 	}
 
 	return fuseMount(target, s3fsCmd, args)

--- a/pkg/mounter/s3fs.go
+++ b/pkg/mounter/s3fs.go
@@ -50,6 +50,14 @@ func (s3fs *s3fsMounter) Mount(source string, target string) error {
 		"-o", "allow_other",
 		"-o", "mp_umask=000",
 	}
+
+	if s3fs.meta.Gid != 0 {
+		args = append(args, fmt.Sprintf("-o", fmt.Sprintf("gid=%d", s3fs.meta.Gid)))
+	}
+	if s3fs.meta.Uid != 0 {
+		args = append(args, fmt.Sprintf("-o", fmt.Sprintf("uid=%d", s3fs.meta.Uid)))
+	}
+
 	return fuseMount(target, s3fsCmd, args)
 }
 

--- a/pkg/s3/client.go
+++ b/pkg/s3/client.go
@@ -5,12 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/golang/glog"
-	"github.com/minio/minio-go/v7"
-	"github.com/minio/minio-go/v7/pkg/credentials"
 	"io"
 	"net/url"
 	"path"
+
+	"github.com/golang/glog"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
 )
 
 const (
@@ -39,6 +40,8 @@ type FSMeta struct {
 	Mounter       string `json:"Mounter"`
 	FSPath        string `json:"FSPath"`
 	CapacityBytes int64  `json:"CapacityBytes"`
+	Uid           uint32 `json:"Uid"`
+	Gid           uint32 `json:"Gid"`
 }
 
 func NewClient(cfg *Config) (*s3Client, error) {


### PR DESCRIPTION
It can be specified in StorageClass like this:

```
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: csi-s3-ctrox-rclone
provisioner: ch.ctrox.csi.s3-driver
parameters:
  mounter: rclone
  usePrefix: "true"
  gid: "33"
  uid: "33"
reclaimPolicy: Retain
volumeBindingMode: Immediate

```


Also changed version to 1.3.0